### PR TITLE
fix: add missing event field validation in edit_img handler

### DIFF
--- a/lambda/src/edit_img/handler.py
+++ b/lambda/src/edit_img/handler.py
@@ -76,6 +76,9 @@ def handler(event: dict[str, Any], context: object) -> dict[str, str]:  # noqa: 
     title = cast("str", event.get("DishName"))
     image_key = cast("str", event.get("ImgKey"))
     exec_name = cast("str", event.get("ExecName"))
+    if not all([title, image_key, exec_name]):
+        msg = "Required event fields are missing"
+        raise ValueError(msg)
 
     return main(
         title,


### PR DESCRIPTION
This PR fixes the missing event field existence checks in the edit_img Lambda handler.

## Changes
- Added validation for required fields (DishName, ImgKey, ExecName)
- Follows the same pattern as gen_img and pub_img handlers
- Prevents runtime errors when required fields are missing

## Testing
Please run the following commands to verify the changes:
```bash
cd lambda
make format
make mypy
make test
```

Fixes #15

Generated with [Claude Code](https://claude.ai/code)