### PR TITLE
feat: parallelize GenImg function execution in Step Functions

### DIFF
--- a/iac-v2/lib/sfn-stack.ts
+++ b/iac-v2/lib/sfn-stack.ts
@@ -254,7 +254,7 @@ const createStateMachine = (
       TitleImgKey: sfn.JsonPath.stringAt(
         "$.EditImgResults.Payload.TitleImgKey",
       ),
-      ImgKey: sfn.JsonPath.stringAt("$.GenImgResults0.Payload.ImgKey"),
+      ImgKey: sfn.JsonPath.stringAt("$.GenImgResults-0.Payload.ImgKey"),
       DryRun: sfn.JsonPath.stringAt("$.DryRun"),
     }),
     integrationPattern: sfn.IntegrationPattern.REQUEST_RESPONSE,

--- a/iac-v2/lib/sfn-stack.ts
+++ b/iac-v2/lib/sfn-stack.ts
@@ -231,7 +231,7 @@ const createStateMachine = (
   const editImgStep = new sfn_tasks.LambdaInvoke(scope, "EditImg", {
     lambdaFunction: editImgFunction,
     payload: sfn.TaskInput.fromObject({
-      ImgKey: sfn.JsonPath.stringAt("$.GenImgResults0.Payload.ImgKey"),
+      ImgKey: sfn.JsonPath.stringAt("$.GenImgResults-0.Payload.ImgKey"),
       DishName: sfn.JsonPath.stringAt("$.GenTextResults.Payload.DishName"),
       BucketName: bucketName,
       ExecName: sfn.JsonPath.stringAt("$$.Execution.Name"),


### PR DESCRIPTION
- Add PARALLEL_COUNT constant set to 4
- Modify Step Functions definition to run GenImg in parallel
- Add ParallelIndex to each parallel execution payload
- Update downstream steps to use first parallel result