### PR TITLE
Remove unnecessary entries from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,6 @@ Step Functions orchestrates Lambda functions. Deployed to ap-northeast-1, trigge
 - Add `--trailer "Reported-by:<name>"` for bug fixes from user reports
 - Add `--trailer "Github-Issue:#<number>"` for issue-related commits
 - NEVER mention co-authored-by or the tool used to create commits/PRs
-- PR reviewers: always add `jerome3o-anthropic` and `jspahrsummers`
 - PR descriptions: focus on the problem being solved and the approach, not code-level details
 
 ## CI/CD

--- a/lambda/CLAUDE.md
+++ b/lambda/CLAUDE.md
@@ -45,8 +45,6 @@ This document contains critical information about working with this codebase. Fo
   the problem it tries to solve, and how it is solved. Don't go into the specifics of the
   code unless it adds clarity.
 
-- Always add `jerome3o-anthropic` and `jspahrsummers` as reviewer.
-
 - NEVER ever mention a `co-authored-by` or similar aspects. In particular, never
   mention the tool used to create the commit message or PR.
 


### PR DESCRIPTION
## Problem

CLAUDE.md にこのリポジトリの運用に当てはまらない記載が残っていた。実態と合わない指示は、毎回それに従おうとして無駄な手順が発生する原因になる。

## Approach

該当する記載をルートの `CLAUDE.md` と `lambda/CLAUDE.md` から削除した。ドキュメントのみの変更で、コードへの影響はない。